### PR TITLE
Add a new functionality to list all items with custom pagination

### DIFF
--- a/src/main/java/com/emazon/stock_service/application/handler/IItemHandler.java
+++ b/src/main/java/com/emazon/stock_service/application/handler/IItemHandler.java
@@ -1,7 +1,12 @@
 package com.emazon.stock_service.application.handler;
 
+import com.emazon.stock_service.application.dto.item.ItemRequest;
+import com.emazon.stock_service.application.dto.item.ItemResponse;
+import com.emazon.stock_service.domain.model.CustomPagination;
 import com.emazon.stock_service.domain.model.Item;
+import org.springframework.http.ResponseEntity;
 
 public interface IItemHandler {
     void saveItem(Item item);
+    ResponseEntity<CustomPagination<ItemResponse>> getItemsWithPagination(int size, int page, String sortArgument, boolean isAsc);
 }

--- a/src/main/java/com/emazon/stock_service/application/handler/implementation/ItemHandler.java
+++ b/src/main/java/com/emazon/stock_service/application/handler/implementation/ItemHandler.java
@@ -1,18 +1,61 @@
 package com.emazon.stock_service.application.handler.implementation;
 
+import com.emazon.stock_service.application.dto.item.ItemRequest;
+import com.emazon.stock_service.application.dto.item.ItemResponse;
 import com.emazon.stock_service.application.handler.IItemHandler;
+import com.emazon.stock_service.application.mapper.IBrandDtoMapper;
+import com.emazon.stock_service.application.mapper.ICategoryDtoMapper;
+import com.emazon.stock_service.application.mapper.item.IItemResponseMapper;
+import com.emazon.stock_service.domain.api.IBrandServicePort;
+import com.emazon.stock_service.domain.api.ICategoryServicePort;
 import com.emazon.stock_service.domain.api.IItemServicePort;
+import com.emazon.stock_service.domain.model.CustomPagination;
 import com.emazon.stock_service.domain.model.Item;
+import com.emazon.stock_service.domain.utils.PaginationInfo;
+import com.emazon.stock_service.infrastructure.mapper.ICategoryEntityMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ItemHandler implements IItemHandler {
     private final IItemServicePort itemServicePort;
+    private final IItemResponseMapper itemResponseMapper;
+    private final IBrandServicePort brandServicePort;
+    private final IBrandDtoMapper brandDtoMapper;
+    private final ICategoryDtoMapper categoryDtoMapper;
+    private final ICategoryServicePort categoryServicePort;
 
     @Override
     public void saveItem(Item item) {
         itemServicePort.saveItem(item);
+    }
+
+    @Override
+    public ResponseEntity<CustomPagination<ItemResponse>> getItemsWithPagination(int size, int page, String sortArgument, boolean isAsc) {
+        CustomPagination<Item> itemCustomPagination = itemServicePort.getAllItemsWithPagination(new PaginationInfo(sortArgument, isAsc, size, page));
+        List<Item> items = itemCustomPagination.getData();
+        List<ItemResponse> itemResponses = items.stream().map(item -> {
+            ItemResponse itemResponse = itemResponseMapper.toItemResponse(item);
+            itemResponse.setBrandId(brandDtoMapper.toBrandDto(brandServicePort.getBrandById(item.getBrandId())));
+            itemResponse.setCategoryIdList(categoryDtoMapper.toCategoryDtoList(categoryServicePort.getAllByItemId(item.getItemId())));
+            return itemResponse;
+        }).toList();
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                new CustomPagination<>(
+                        itemResponses,
+                        itemCustomPagination.getElements(),
+                        itemCustomPagination.getPages(),
+                        itemCustomPagination.getCurrentPage(),
+                        itemCustomPagination.isAsc()
+                )
+        );
     }
 }

--- a/src/main/java/com/emazon/stock_service/application/mapper/ICategoryDtoMapper.java
+++ b/src/main/java/com/emazon/stock_service/application/mapper/ICategoryDtoMapper.java
@@ -6,6 +6,8 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 
+import java.util.List;
+
 @Mapper(componentModel = "spring",
         unmappedTargetPolicy = ReportingPolicy.IGNORE,
         unmappedSourcePolicy = ReportingPolicy.IGNORE)
@@ -15,4 +17,6 @@ public interface ICategoryDtoMapper {
 
     @Mapping(target = "name", source = "name")
     CategoryDto toCategoryDto(Category category);
+
+    List<CategoryDto> toCategoryDtoList(List<Category> categories);
 }

--- a/src/main/java/com/emazon/stock_service/application/mapper/item/IItemResponseMapper.java
+++ b/src/main/java/com/emazon/stock_service/application/mapper/item/IItemResponseMapper.java
@@ -1,7 +1,37 @@
 package com.emazon.stock_service.application.mapper.item;
 
+import com.emazon.stock_service.application.dto.BrandDto;
+import com.emazon.stock_service.application.dto.CategoryDto;
+import com.emazon.stock_service.application.dto.item.ItemResponse;
+import com.emazon.stock_service.application.mapper.IBrandDtoMapper;
+import com.emazon.stock_service.application.mapper.ICategoryDtoMapper;
+import com.emazon.stock_service.domain.api.IBrandServicePort;
+import com.emazon.stock_service.domain.model.Item;
+import com.emazon.stock_service.domain.usecase.BrandUseCase;
+import java.util.Collections;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
-@Mapper(componentModel = "spring")
+import java.util.List;
+
+@Mapper(componentModel = "spring", uses = {
+        ICategoryDtoMapper.class,
+        IBrandDtoMapper.class,
+        IBrandServicePort.class
+})
 public interface IItemResponseMapper {
+    @Mapping(source = "brandId", target = "brandId", qualifiedByName = "nullBrandDto")
+    @Mapping(source = "categoryIdList", target = "categoryIdList", qualifiedByName = "nullCategoryDtoList")
+    ItemResponse toItemResponse(Item item);
+
+    @Named("nullBrandDto")
+    default BrandDto nullBrandDto(Long brandId) {
+        return null;
+    }
+
+    @Named("nullCategoryDtoList")
+    default List<CategoryDto> nullCategoryDtoList(List<Long> categoryIdList) {
+        return Collections.emptyList();
+    }
 }

--- a/src/main/java/com/emazon/stock_service/domain/api/IBrandServicePort.java
+++ b/src/main/java/com/emazon/stock_service/domain/api/IBrandServicePort.java
@@ -7,4 +7,5 @@ import java.util.List;
 public interface IBrandServicePort {
     void saveBrand(Brand brand);
     List<Brand> getAllBrands(String order);
+    Brand getBrandById(Long brandId);
 }

--- a/src/main/java/com/emazon/stock_service/domain/api/ICategoryServicePort.java
+++ b/src/main/java/com/emazon/stock_service/domain/api/ICategoryServicePort.java
@@ -7,4 +7,5 @@ import java.util.List;
 public interface ICategoryServicePort {
     void saveCategory(Category category);
     List<Category> getAllCategories(String order);
+    List<Category> getAllByItemId(Long itemId);
 }

--- a/src/main/java/com/emazon/stock_service/domain/api/IItemServicePort.java
+++ b/src/main/java/com/emazon/stock_service/domain/api/IItemServicePort.java
@@ -1,7 +1,10 @@
 package com.emazon.stock_service.domain.api;
 
+import com.emazon.stock_service.domain.model.CustomPagination;
 import com.emazon.stock_service.domain.model.Item;
+import com.emazon.stock_service.domain.utils.PaginationInfo;
 
 public interface IItemServicePort {
     void saveItem(Item item);
+    CustomPagination<Item> getAllItemsWithPagination(PaginationInfo paginationInfo);
 }

--- a/src/main/java/com/emazon/stock_service/domain/model/CustomPagination.java
+++ b/src/main/java/com/emazon/stock_service/domain/model/CustomPagination.java
@@ -1,0 +1,69 @@
+package com.emazon.stock_service.domain.model;
+
+import java.util.List;
+
+public class CustomPagination<T> {
+    private List<T> data;
+    private Long elements;
+    private int pages;
+    private int currentPage;
+    private boolean asc;
+    private boolean empty;
+
+    public CustomPagination(List<T> data, Long elements, int pages, int currentPage, boolean asc) {
+        this.data = data;
+        this.elements = elements;
+        this.pages = pages;
+        this.currentPage = currentPage;
+        this.asc = asc;
+        this.empty = data.isEmpty();
+    }
+
+    public List<T> getData() {
+        return data;
+    }
+
+    public void setData(List<T> data) {
+        this.data = data;
+    }
+
+    public Long getElements() {
+        return elements;
+    }
+
+    public void setElements(Long elements) {
+        this.elements = elements;
+    }
+
+    public int getPages() {
+        return pages;
+    }
+
+    public void setPages(int pages) {
+        this.pages = pages;
+    }
+
+    public int getCurrentPage() {
+        return currentPage;
+    }
+
+    public void setCurrentPage(int currentPage) {
+        this.currentPage = currentPage;
+    }
+
+    public boolean isAsc() {
+        return asc;
+    }
+
+    public void setAsc(boolean asc) {
+        this.asc = asc;
+    }
+
+    public boolean isEmpty() {
+        return empty;
+    }
+
+    public void setEmpty(boolean empty) {
+        this.empty = empty;
+    }
+}

--- a/src/main/java/com/emazon/stock_service/domain/model/Item.java
+++ b/src/main/java/com/emazon/stock_service/domain/model/Item.java
@@ -3,7 +3,7 @@ package com.emazon.stock_service.domain.model;
 import java.util.List;
 
 public class Item {
-    private String itemId;
+    private Long itemId;
     private String itemName;
     private String itemDescription;
     private Integer itemQuantity;
@@ -14,7 +14,7 @@ public class Item {
     public Item() {
     }
 
-    public Item(String itemId, String itemName, String itemDescription, Integer itemQuantity, Double itemPrice, Long brandId, List<Long> categoryIdList) {
+    public Item(Long itemId, String itemName, String itemDescription, Integer itemQuantity, Double itemPrice, Long brandId, List<Long> categoryIdList) {
         this.itemId = itemId;
         this.itemName = itemName;
         this.itemDescription = itemDescription;
@@ -24,11 +24,11 @@ public class Item {
         this.categoryIdList = categoryIdList;
     }
 
-    public String getItemId() {
+    public Long getItemId() {
         return itemId;
     }
 
-    public void setItemId(String itemId) {
+    public void setItemId(Long itemId) {
         this.itemId = itemId;
     }
 

--- a/src/main/java/com/emazon/stock_service/domain/spi/IBrandPersistentPort.java
+++ b/src/main/java/com/emazon/stock_service/domain/spi/IBrandPersistentPort.java
@@ -8,4 +8,5 @@ public interface IBrandPersistentPort {
     void saveBrand(Brand brand);
     boolean existsByName(String name);
     List<Brand> getBrands(String order);
+    Brand getBrandById(Long brandId);
 }

--- a/src/main/java/com/emazon/stock_service/domain/spi/ICategoryPersistentPort.java
+++ b/src/main/java/com/emazon/stock_service/domain/spi/ICategoryPersistentPort.java
@@ -8,4 +8,5 @@ public interface ICategoryPersistentPort {
     void saveCategory(Category category);
     boolean existsByName(String name);
     List<Category> getCategories(String order);
+    List<Category> getAllByItemId(Long itemId);
 }

--- a/src/main/java/com/emazon/stock_service/domain/spi/IItemPersistentPort.java
+++ b/src/main/java/com/emazon/stock_service/domain/spi/IItemPersistentPort.java
@@ -1,7 +1,10 @@
 package com.emazon.stock_service.domain.spi;
 
+import com.emazon.stock_service.domain.model.CustomPagination;
 import com.emazon.stock_service.domain.model.Item;
+import com.emazon.stock_service.domain.utils.PaginationInfo;
 
 public interface IItemPersistentPort {
     void saveItem(Item item);
+    CustomPagination<Item> getAllItemsWithPagination(PaginationInfo paginationInfo);
 }

--- a/src/main/java/com/emazon/stock_service/domain/usecase/BrandUseCase.java
+++ b/src/main/java/com/emazon/stock_service/domain/usecase/BrandUseCase.java
@@ -32,4 +32,9 @@ public class BrandUseCase implements IBrandServicePort {
         ValidationUtils.validateOrderString(order);
         return brandPersistentPort.getBrands(order);
     }
+
+    @Override
+    public Brand getBrandById(Long brandId) {
+        return brandPersistentPort.getBrandById(brandId);
+    }
 }

--- a/src/main/java/com/emazon/stock_service/domain/usecase/CategoryUseCase.java
+++ b/src/main/java/com/emazon/stock_service/domain/usecase/CategoryUseCase.java
@@ -32,4 +32,9 @@ public class CategoryUseCase implements ICategoryServicePort {
         ValidationUtils.validateOrderString(order);
         return categoryPersistentPort.getCategories(order);
     }
+
+    @Override
+    public List<Category> getAllByItemId(Long itemId) {
+        return categoryPersistentPort.getAllByItemId(itemId);
+    }
 }

--- a/src/main/java/com/emazon/stock_service/domain/usecase/ItemUseCase.java
+++ b/src/main/java/com/emazon/stock_service/domain/usecase/ItemUseCase.java
@@ -20,6 +20,6 @@ public class ItemUseCase implements IItemServicePort {
 
     @Override
     public CustomPagination<Item> getAllItemsWithPagination(PaginationInfo paginationInfo) {
-        return null;
+        return itemPersistentPort.getAllItemsWithPagination(paginationInfo);
     }
 }

--- a/src/main/java/com/emazon/stock_service/domain/usecase/ItemUseCase.java
+++ b/src/main/java/com/emazon/stock_service/domain/usecase/ItemUseCase.java
@@ -1,8 +1,10 @@
 package com.emazon.stock_service.domain.usecase;
 
 import com.emazon.stock_service.domain.api.IItemServicePort;
+import com.emazon.stock_service.domain.model.CustomPagination;
 import com.emazon.stock_service.domain.model.Item;
 import com.emazon.stock_service.domain.spi.IItemPersistentPort;
+import com.emazon.stock_service.domain.utils.PaginationInfo;
 
 public class ItemUseCase implements IItemServicePort {
     private final IItemPersistentPort itemPersistentPort;
@@ -14,5 +16,10 @@ public class ItemUseCase implements IItemServicePort {
     @Override
     public void saveItem(Item item) {
         itemPersistentPort.saveItem(item);
+    }
+
+    @Override
+    public CustomPagination<Item> getAllItemsWithPagination(PaginationInfo paginationInfo) {
+        return null;
     }
 }

--- a/src/main/java/com/emazon/stock_service/domain/utils/PaginationInfo.java
+++ b/src/main/java/com/emazon/stock_service/domain/utils/PaginationInfo.java
@@ -1,0 +1,47 @@
+package com.emazon.stock_service.domain.utils;
+
+public class PaginationInfo {
+    private String sortBy;
+    private boolean asc;
+    private int pageSize;
+    private int pageNumber;
+
+    public PaginationInfo(String sortBy, boolean asc, int pageSize, int pageNumber) {
+        this.sortBy = sortBy;
+        this.asc = asc;
+        this.pageSize = pageSize;
+        this.pageNumber = pageNumber;
+    }
+
+    public String getSortBy() {
+        return sortBy;
+    }
+
+    public void setSortBy(String sortBy) {
+        this.sortBy = sortBy;
+    }
+
+    public boolean isAsc() {
+        return asc;
+    }
+
+    public void setAsc(boolean asc) {
+        this.asc = asc;
+    }
+
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    public int getPageNumber() {
+        return pageNumber;
+    }
+
+    public void setPageNumber(int pageNumber) {
+        this.pageNumber = pageNumber;
+    }
+}

--- a/src/main/java/com/emazon/stock_service/domain/utils/SortArgument.java
+++ b/src/main/java/com/emazon/stock_service/domain/utils/SortArgument.java
@@ -1,0 +1,15 @@
+package com.emazon.stock_service.domain.utils;
+
+public enum SortArgument {
+    ITEM_NAME("itemName"), BRAND_NAME("brandName"), NUMBER_OF_CATEGORIES("numberOfCategories");
+
+    private final String field;
+
+    SortArgument(String field) {
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+}

--- a/src/main/java/com/emazon/stock_service/infrastructure/adapter/BrandJpaAdapter.java
+++ b/src/main/java/com/emazon/stock_service/infrastructure/adapter/BrandJpaAdapter.java
@@ -40,4 +40,11 @@ public class BrandJpaAdapter implements IBrandPersistentPort {
             throw new BrandException(e.getMessage());
         }
     }
+
+    @Override
+    public Brand getBrandById(Long brandId) {
+        return brandRepository.findById(brandId)
+                .map(brandEntityMapper::toBrand)
+                .orElseThrow(() -> new BrandException("Brand with id " + brandId + " not found."));
+    }
 }

--- a/src/main/java/com/emazon/stock_service/infrastructure/adapter/CategoryJpaAdapter.java
+++ b/src/main/java/com/emazon/stock_service/infrastructure/adapter/CategoryJpaAdapter.java
@@ -2,6 +2,7 @@ package com.emazon.stock_service.infrastructure.adapter;
 
 import com.emazon.stock_service.domain.model.Category;
 import com.emazon.stock_service.domain.spi.ICategoryPersistentPort;
+import com.emazon.stock_service.infrastructure.entity.CategoryEntity;
 import com.emazon.stock_service.infrastructure.exception.CategoryException;
 import com.emazon.stock_service.infrastructure.mapper.ICategoryEntityMapper;
 import com.emazon.stock_service.infrastructure.repository.CategoryRepository;
@@ -39,5 +40,11 @@ public class CategoryJpaAdapter implements ICategoryPersistentPort {
         } catch (Exception e) {
             throw new CategoryException(e.getMessage());
         }
+    }
+
+    @Override
+    public List<Category> getAllByItemId(Long itemId) {
+        List<CategoryEntity> categories = categoryRepository.findCategoriesByItemId(itemId);
+        return categoryEntityMapper.toCategoryList(categories);
     }
 }

--- a/src/main/java/com/emazon/stock_service/infrastructure/adapter/ItemJpaAdapter.java
+++ b/src/main/java/com/emazon/stock_service/infrastructure/adapter/ItemJpaAdapter.java
@@ -4,10 +4,17 @@ import com.emazon.stock_service.domain.model.CustomPagination;
 import com.emazon.stock_service.domain.model.Item;
 import com.emazon.stock_service.domain.spi.IItemPersistentPort;
 import com.emazon.stock_service.domain.utils.PaginationInfo;
+import com.emazon.stock_service.domain.utils.SortArgument;
+import com.emazon.stock_service.infrastructure.entity.ItemEntity;
 import com.emazon.stock_service.infrastructure.mapper.IItemEntityMapper;
 import com.emazon.stock_service.infrastructure.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
 
 @Component
 @RequiredArgsConstructor
@@ -22,6 +29,32 @@ public class ItemJpaAdapter implements IItemPersistentPort {
 
     @Override
     public CustomPagination<Item> getAllItemsWithPagination(PaginationInfo paginationInfo) {
-        return null;
+        PageRequest pageRequest = PageRequest.of(paginationInfo.getPageNumber(), paginationInfo.getPageSize());
+        Page<ItemEntity> itemPage = null;
+
+        if (Objects.equals(SortArgument.ITEM_NAME.getField(), paginationInfo.getSortBy())) {
+            itemPage = paginationInfo.isAsc()
+                    ? itemRepository.findAllOrderByItemNameAsc(pageRequest)
+                    : itemRepository.findAllOrderByItemNameDesc(pageRequest);
+        } else if (Objects.equals(SortArgument.BRAND_NAME.getField(), paginationInfo.getSortBy())) {
+            itemPage = paginationInfo.isAsc()
+                    ? itemRepository.findAllOrderByNameAsc(pageRequest)
+                    : itemRepository.findAllOrderByNameDesc(pageRequest);
+        } else if (Objects.equals(SortArgument.NUMBER_OF_CATEGORIES.getField(), paginationInfo.getSortBy())) {
+            itemPage = paginationInfo.isAsc()
+                    ? itemRepository.findAllOrderByNumberOfCategoryIdListAsc(pageRequest)
+                    : itemRepository.findAllOrderByNumberOfCategoryIdListDesc(pageRequest);
+        }
+
+        assert itemPage != null;
+        List<Item> items = itemEntityMapper.toItemList(itemPage.getContent());
+
+        return new CustomPagination<>(
+                items,
+                itemPage.getTotalElements(),
+                itemPage.getTotalPages(),
+                paginationInfo.getPageNumber(),
+                paginationInfo.isAsc()
+        );
     }
 }

--- a/src/main/java/com/emazon/stock_service/infrastructure/adapter/ItemJpaAdapter.java
+++ b/src/main/java/com/emazon/stock_service/infrastructure/adapter/ItemJpaAdapter.java
@@ -1,7 +1,9 @@
 package com.emazon.stock_service.infrastructure.adapter;
 
+import com.emazon.stock_service.domain.model.CustomPagination;
 import com.emazon.stock_service.domain.model.Item;
 import com.emazon.stock_service.domain.spi.IItemPersistentPort;
+import com.emazon.stock_service.domain.utils.PaginationInfo;
 import com.emazon.stock_service.infrastructure.mapper.IItemEntityMapper;
 import com.emazon.stock_service.infrastructure.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,5 +18,10 @@ public class ItemJpaAdapter implements IItemPersistentPort {
     @Override
     public void saveItem(Item item) {
         itemRepository.save(itemEntityMapper.toItemEntity(item));
+    }
+
+    @Override
+    public CustomPagination<Item> getAllItemsWithPagination(PaginationInfo paginationInfo) {
+        return null;
     }
 }

--- a/src/main/java/com/emazon/stock_service/infrastructure/controller/ItemController.java
+++ b/src/main/java/com/emazon/stock_service/infrastructure/controller/ItemController.java
@@ -1,8 +1,10 @@
 package com.emazon.stock_service.infrastructure.controller;
 
 import com.emazon.stock_service.application.dto.item.ItemRequest;
+import com.emazon.stock_service.application.dto.item.ItemResponse;
 import com.emazon.stock_service.application.handler.IItemHandler;
 import com.emazon.stock_service.application.mapper.item.IItemRequestMapper;
+import com.emazon.stock_service.domain.model.CustomPagination;
 import com.emazon.stock_service.infrastructure.utils.docs.ItemRestControllerConstants;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,10 +13,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/items")
@@ -35,5 +35,15 @@ public class ItemController {
                     required = true)
             @Valid @RequestBody ItemRequest itemRequest) {
         itemHandler.saveItem(requestMapper.toItem(itemRequest));
+    }
+
+    @GetMapping
+    public ResponseEntity<CustomPagination<ItemResponse>> getItemsWithPagination(
+            @RequestParam(defaultValue = "itemName", required = false) String sortArgument,
+            @RequestParam(defaultValue = "0", required = false) int page,
+            @RequestParam(defaultValue = "10", required = false) int size,
+            @RequestParam(defaultValue = "true", required = false) boolean isAsc
+    ) {
+        return itemHandler.getItemsWithPagination(size, page, sortArgument, isAsc);
     }
 }

--- a/src/main/java/com/emazon/stock_service/infrastructure/entity/BrandEntity.java
+++ b/src/main/java/com/emazon/stock_service/infrastructure/entity/BrandEntity.java
@@ -13,8 +13,13 @@ import java.util.List;
 public class BrandEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "brand_id")
     private Long id;
+
+    @Column(name = "brand_name", unique = true)
     private String name;
+
+    @Column(name = "brand_description")
     private String description;
 
     @OneToMany(mappedBy = "brandId", fetch = FetchType.LAZY)

--- a/src/main/java/com/emazon/stock_service/infrastructure/mapper/ICategoryEntityMapper.java
+++ b/src/main/java/com/emazon/stock_service/infrastructure/mapper/ICategoryEntityMapper.java
@@ -6,6 +6,8 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 
+import java.util.List;
+
 @Mapper(componentModel = "spring",
         unmappedTargetPolicy = ReportingPolicy.IGNORE,
         unmappedSourcePolicy = ReportingPolicy.IGNORE)
@@ -15,4 +17,6 @@ public interface ICategoryEntityMapper {
 
     @Mapping(target = "name", source = "name")
     Category toCategory(CategoryEntity categoryEntity);
+
+    List<Category> toCategoryList(List<CategoryEntity> categoryEntityList);
 }

--- a/src/main/java/com/emazon/stock_service/infrastructure/mapper/IItemEntityMapper.java
+++ b/src/main/java/com/emazon/stock_service/infrastructure/mapper/IItemEntityMapper.java
@@ -1,6 +1,7 @@
 package com.emazon.stock_service.infrastructure.mapper;
 
 import com.emazon.stock_service.domain.model.Item;
+import com.emazon.stock_service.infrastructure.entity.BrandEntity;
 import com.emazon.stock_service.infrastructure.entity.CategoryEntity;
 import com.emazon.stock_service.infrastructure.entity.ItemEntity;
 import org.mapstruct.Mapper;
@@ -18,8 +19,22 @@ public interface IItemEntityMapper {
     @Mapping(source = "categoryIdList", target = "categoryIdList", qualifiedByName = "idToCategory")
     ItemEntity toItemEntity(Item item);
 
-    @Mapping(source = "categoryIdList", target = "categoryIdList")
+    @Mapping(source = "brandId", target = "brandId", qualifiedByName = "brandEntityToId")
+    @Mapping(source = "categoryIdList", target = "categoryIdList", qualifiedByName = "categoryEntityListToLongList")
+    Item toItem(ItemEntity itemEntity);
+
+    @Mapping(source = "categoryIdList", target = "categoryIdList", qualifiedByName = "categoryEntityListToLongList")
     List<Item> toItemList(List<ItemEntity> itemEntityList);
+
+    @Named("brandEntityToId")
+    default Long brandEntityToId(BrandEntity brandEntity) {
+        return brandEntity.getId();
+    }
+
+    @Named("categoryEntityListToLongList")
+    default List<Long> categoryEntityListToLongList(List<CategoryEntity> categoryEntityList) {
+        return categoryEntityList.stream().map(CategoryEntity::getId).toList();
+    }
 
     @Named("idToCategory")
     default CategoryEntity idToCategory(Long categoryId) {

--- a/src/main/java/com/emazon/stock_service/infrastructure/mapper/IItemEntityMapper.java
+++ b/src/main/java/com/emazon/stock_service/infrastructure/mapper/IItemEntityMapper.java
@@ -7,6 +7,8 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 
+import java.util.List;
+
 @Mapper(componentModel = "spring", uses = {
         ICategoryEntityMapper.class,
         IBrandEntityMapper.class,
@@ -15,6 +17,9 @@ public interface IItemEntityMapper {
     @Mapping(source = "brandId", target = "brandId", qualifiedByName = "idToBrand")
     @Mapping(source = "categoryIdList", target = "categoryIdList", qualifiedByName = "idToCategory")
     ItemEntity toItemEntity(Item item);
+
+    @Mapping(source = "categoryIdList", target = "categoryIdList")
+    List<Item> toItemList(List<ItemEntity> itemEntityList);
 
     @Named("idToCategory")
     default CategoryEntity idToCategory(Long categoryId) {

--- a/src/main/java/com/emazon/stock_service/infrastructure/repository/CategoryRepository.java
+++ b/src/main/java/com/emazon/stock_service/infrastructure/repository/CategoryRepository.java
@@ -2,10 +2,18 @@ package com.emazon.stock_service.infrastructure.repository;
 
 import com.emazon.stock_service.infrastructure.entity.CategoryEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<CategoryEntity, Long> {
     boolean existsByNameIgnoreCase(String name);
     Optional<CategoryEntity> findByNameIgnoreCase(String name);
+
+    @Query("SELECT c FROM CategoryEntity c JOIN c.items i WHERE i.itemId = :itemId ORDER BY c.name ASC")
+    List<CategoryEntity> findCategoriesByItemId(
+            @Param("itemId") Long itemId
+    );
 }

--- a/src/main/java/com/emazon/stock_service/infrastructure/repository/ItemRepository.java
+++ b/src/main/java/com/emazon/stock_service/infrastructure/repository/ItemRepository.java
@@ -1,7 +1,33 @@
 package com.emazon.stock_service.infrastructure.repository;
 
 import com.emazon.stock_service.infrastructure.entity.ItemEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ItemRepository extends JpaRepository<ItemEntity, Long> {
+    // ASC
+    @Query("SELECT i FROM ItemEntity i ORDER BY i.itemName ASC")
+    Page<ItemEntity> findAllOrderByItemNameAsc(Pageable pageable);
+
+    @Query("SELECT i FROM ItemEntity i JOIN i.brandId b ORDER BY b.name ASC")
+    Page<ItemEntity> findAllOrderByNameAsc(Pageable pageable);
+
+    @Query("SELECT i FROM ItemEntity i LEFT JOIN i.categoryIdList c " +
+            "GROUP BY i.itemId " +
+            "ORDER BY COUNT(c.id) ASC, MIN(c.name) ASC")
+    Page<ItemEntity> findAllOrderByNumberOfCategoryIdListAsc(Pageable pageable);
+
+    // DESC
+    @Query("SELECT i FROM ItemEntity i ORDER BY i.itemName DESC")
+    Page<ItemEntity> findAllOrderByItemNameDesc(Pageable pageable);
+
+    @Query("SELECT i FROM ItemEntity i JOIN i.brandId b ORDER BY b.name DESC")
+    Page<ItemEntity> findAllOrderByNameDesc(Pageable pageable);
+
+    @Query("SELECT i FROM ItemEntity i LEFT JOIN i.categoryIdList c " +
+            "GROUP BY i.itemId " +
+            "ORDER BY COUNT(c.id) DESC, MIN(c.name) ASC")
+    Page<ItemEntity> findAllOrderByNumberOfCategoryIdListDesc(Pageable pageable);
 }


### PR DESCRIPTION
This PR implements the functionality of listing all items with pagination. This includes:

- A new GET method implementation in the `/api/v1/items` endpoint.
- Generates a custom pagination response.

### Pending tasks
- Add OpenAPI docs.
- Validate code with SonarLint.

### Implemented user stories
- HU006